### PR TITLE
Limit concurrent requests to Trellis to 2

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "trellis": {
-    "basePath": "https://trellis.sinopia.io"
+    "basePath": "https://trellis.sinopia.io",
+    "poolLimit": 2
   },
   "exportBasePath": "./exported_rdf"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7909,6 +7909,15 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tiny-async-pool": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.0.4.tgz",
+      "integrity": "sha512-4gdLvReS3WwmPCxZjj38Go673xhEXlK77fVFA2x+dE2Bf9QzDkVQb3rdO1iJt337ybhir42m4zM2GHJjiuFwoA==",
+      "requires": {
+        "semver": "^5.5.0",
+        "yaassertion": "^1.0.0"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -8375,6 +8384,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaassertion": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yaassertion/-/yaassertion-1.0.2.tgz",
+      "integrity": "sha512-sBoJBg5vTr3lOpRX0yFD+tz7wv/l2UPMFthag4HGTMPrypBRKerjjS8jiEnNMjcAEtPXjbHiKE0UwRR1W1GXBg=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@babel/runtime": "^7.7.2",
     "config": "^3.2.4",
     "honeybadger": "^1.3.0",
-    "sinopia_server": "^3.0.2"
+    "sinopia_server": "^3.0.2",
+    "tiny-async-pool": "^1.0.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.6.2",

--- a/src/cli/exportAndSave.js
+++ b/src/cli/exportAndSave.js
@@ -59,9 +59,9 @@ exported_rdf/
 console.info(`sinopia_exporter v${sinopiaExporter.version}`)
 
 const groupName = process.argv[2]
-if(groupName) {
+if (groupName) {
   // TODO: better command line parsing with yargs, see https://github.com/LD4P/sinopia_exporter/issues/38
-  if(groupName == '_ALL_') {
+  if (groupName == '_ALL_') {
     downloadAllRdfForAllGroups()
   } else {
     downloadAllRdfForGroup(groupName)


### PR DESCRIPTION
Use same approach used in sinopia_indexing_pipeline, and allow it to vary based on configuration.

Fixes #63 