### PR TITLE
Branch renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
             tags:
               ignore:
                 - /v.*/


### PR DESCRIPTION
Rename `master` branch to `main` branch in circleci yml. 