### PR TITLE
remove version specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "sinopia_exporter",
-  "version": "2.0.8",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -6121,7 +6120,8 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "sinopia_exporter",
-  "version": "2.0.8",
   "description": "Export RDF entities from a group in Sinopia Server (Sinopia's particular configuration of trellis-ext-db)",
   "scripts": {
     "eslint": "eslint --max-warnings 0 --color -c .eslintrc.js --ext js,jsx .",


### PR DESCRIPTION
since we don't intend to keep publishing this for consumption, and since we tend not to update package.json version when we tag a new release for weekly dependency update deployment.

i'll note that `npm i` didn't give any warnings or errors when i omitted the version, unlike when i tried to use a version other than `MAJOR.MINOR.PATCH` with only numeric values for each part.  e.g. `npm i` warned about `2`, `2.1`, and `2.1.x`:
* `npm WARN Invalid version: "2.1"`
* `npm WARN Invalid version: "2.1.x"`
* `npm WARN Invalid version: "2"`

discussed with @jermnelson and he voted for just omitting the version.

ref https://github.com/LD4P/sinopia/issues/316