### PR TITLE
update tests to reflect new group response with label

### DIFF
--- a/__tests__/exporter.test.js
+++ b/__tests__/exporter.test.js
@@ -11,9 +11,9 @@ const resource2 = require('./__fixtures__/6d9e3c1b-fc26-4ff2-9951-435ff86e4971.j
 const resource3 = require('./__fixtures__/6f30cb1a-676d-4d5d-9f54-32162c9ab573.json')
 
 const groups = [
-  { 'id': 'group1'},
-  { 'id': 'group2'},
-  { 'id': 'group3'}
+  { 'id': 'group1', 'label': 'Group 1'},
+  { 'id': 'group2', 'label': 'Group 2'},
+  { 'id': 'group3', 'label': 'Group 3'}
 ]
 
 afterAll(async () => {

--- a/__tests__/sinopia_client.test.js
+++ b/__tests__/sinopia_client.test.js
@@ -7,7 +7,7 @@ jest.mock('node-fetch', ()=>jest.fn())
 
 describe('query', () => {
   it('successfully resolves the promise when response status is OK', async () => {
-    const responseBody = { "data": {} }
+    const responseBody = { "data": [{ id: 'group1', label: 'Group 1'}, { id: 'group2', label: 'Group 2'}] }
 
     const response = Promise.resolve({
       ok: true,
@@ -15,7 +15,7 @@ describe('query', () => {
     })
     fetch.mockImplementation(()=> response)
 
-    expect(await sinopia_client.query("http://localhost:3000/groups")).toStrictEqual({ data: {} })
+    expect(await sinopia_client.query("http://localhost:3000/groups")).toStrictEqual(responseBody)
   })
 
   it('returns null if the api call fails', async () => {


### PR DESCRIPTION
Fixes #222 

The sinopia_api groups endpoint response data structure changed here: https://github.com/LD4P/sinopia_api/pull/172
This makes some changes based on the data structure change.

Note: I don't think we need any more changes in the code, as the new data structure now just includes a `label` attribute, where before it didn't.  I presume our exporter code doesn't need to make use of this label, and will continue to identify groups via the `id` attribute, which is still present.  e.g. see https://github.com/LD4P/sinopia_exporter/blob/main/src/exporter.js#L102-L104 ... this should still work just fine with the new groups endpoint.