### PR TITLE
Update github-cli orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   node: circleci/node@5.0.2
   docker: circleci/docker@2.0.3
-  gh: circleci/github-cli@1.0.4
+  gh: circleci/github-cli@2.2.0
 executors:
   default:
     docker:


### PR DESCRIPTION
## Why was this change made?

Bring in latest github-cli orb with (hopefully) updated github pubkey.

## How was this change tested?

This will run the next time dependency updates run on April 3, 2023.

## Which documentation and/or configurations were updated?

None

